### PR TITLE
$refs in property definitions

### DIFF
--- a/src/configurationSearch.ts
+++ b/src/configurationSearch.ts
@@ -1,8 +1,7 @@
 import * as vscode from 'vscode';
 import MiniSearch from 'minisearch';
-import { assert } from 'console';
 
-type Property = { id: string, defaultValue: any; type: string; description?: string; markdownDescription?: string; enum?: string[]; enumDescriptions?: string[]; markdownEnumDescription?: string[] };
+type Property = { $ref?: string, id: string, defaultValue: any; type: string; description?: string; markdownDescription?: string; enum?: string[]; enumDescriptions?: string[]; markdownEnumDescription?: string[] };
 
 export type Configuration = { key: string, default: any; type: string; description: string; };
 
@@ -11,15 +10,31 @@ const configurationSearch = Promise.resolve(setupSearch());
 async function setupSearch(): Promise<MiniSearch<Configuration>> {
 	const defaultSettingsSchemaResource = vscode.Uri.parse('vscode://schemas/settings/default');
 	const textDocument = await vscode.workspace.openTextDocument(defaultSettingsSchemaResource);
-	const settings = JSON.parse(textDocument.getText()) as { properties: { [key: string]: Property } };
+	const settings = JSON.parse(textDocument.getText()) as { properties: { [key: string]: Property }, '$defs': { [key: string]: Property } };
 
 	const properties = Object.keys(settings.properties).
 		filter(key => !key.startsWith('[')).
 		map((key, id) => {
-			const property = settings.properties[key];
+			let property = settings.properties[key];
+
+			const reference = property['$ref'];
+			if (reference !== undefined && reference.startsWith('#/$defs/')) {
+				const referenceNumber = reference.split('/').pop();
+				if (referenceNumber === undefined) {
+					throw new Error('Reference number is undefined');
+				}
+
+				const referencedProperty = settings['$defs'][referenceNumber];
+				if (referencedProperty === undefined) {
+					throw new Error('Referenced property does not exist');
+				}
+
+				property = referencedProperty;
+			}
+
 			let description = property.markdownDescription ?? property.description ?? '';
 			if (property.type === 'string' && property.enum && (property.enumDescriptions || property.markdownEnumDescription)) {
-				description += '\nEnums:\n' + enumsDescription(property.enum, property.enumDescriptions ?? property.markdownEnumDescription ?? []);
+				description += '\nAllowed Values:\n' + enumsDescription(property.enum, property.enumDescriptions ?? property.markdownEnumDescription ?? []);
 			}
 
 			return {
@@ -41,17 +56,14 @@ async function setupSearch(): Promise<MiniSearch<Configuration>> {
 }
 
 async function searchConfiguration(keywords: string): Promise<Configuration[]> {
-	const search = (await configurationSearch).search;
-
 	// search for exact match on key
-	let results = search(keywords, { fields: ['key'], prefix: true, filter: (result => result.key === keywords) });
+	let results = (await configurationSearch).search(keywords, { fields: ['key'], prefix: true, filter: (result => result.key === keywords) });
 	if (results.length === 0) {
 		// search based on configuration id and description
-		results = search(keywords, { fields: ['key', 'description'] });
+		results = (await configurationSearch).search(keywords, { fields: ['key', 'description'] });
 	}
 
 	return results.
-		filter(result => result.score > 10).
 		map(result => ({
 			key: result.key,
 			default: result.default,
@@ -66,9 +78,8 @@ export async function getConfigurationsFromKeywords(keywords: string, limit: num
 }
 
 function enumsDescription(enumKeys: string[], enumDescriptions: string[]): string {
-	assert(enumKeys.length === enumDescriptions.length);
-	return enumKeys.map((key, index) => {
-		const description = enumDescriptions[index];
-		return `${key}: ${description}`;
+	return enumKeys.map((enumKey, index) => {
+		const enumDescription = enumDescriptions[index];
+		return `${enumKey}: ${enumDescription}`;
 	}).join('\n');
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,12 @@ export function activate(context: vscode.ExtensionContext) {
 			}));
 
 		const messages = [
-			vscode.LanguageModelChatMessage.User('You are a VS Code commander and your goal is to update settings by using the provided tools. Make sure the setting exists. Do not update the setting if you wont update the value. Never ask the user whether they think you should update the setting, just do it.'),
+			vscode.LanguageModelChatMessage.User(
+				`You are a VS Code commander and your goal is to update settings by using the provided tools. 
+				Make sure the setting exists. Do not update the setting if you won't update the value. 
+				Never ask the user whether they think you should update the setting, just do it.
+				Tell the user which settings have been updated and what the new value is.`
+			),
 		];
 
 		for (const history of context.history) {
@@ -46,7 +51,7 @@ export function activate(context: vscode.ExtensionContext) {
 				return { 'text/plain': 'Unable to call searchSettings without keywords' };
 			}
 			console.log('Keywords:', options.parameters.keywords);
-			const configurations = await getConfigurationsFromKeywords(options.parameters.keywords, 7);
+			const configurations = await getConfigurationsFromKeywords(options.parameters.keywords, 20);
 			console.log('Configurations:', configurations);
 
 			if (token.isCancellationRequested) {
@@ -62,7 +67,8 @@ export function activate(context: vscode.ExtensionContext) {
 					id: c.key,
 					value: vscode.workspace.getConfiguration().get(c.key),
 					defaultValue: c.default,
-					type: c.type
+					type: c.type,
+					description: c.description
 				}))),
 			};
 		},


### PR DESCRIPTION
This pull request introduces support for `$ref` in property definitions, allowing properties to reference definitions within the schema. It updates the handling of settings to accommodate these references, ensuring that referenced properties are correctly resolved and utilized. Additionally, the search functionality has been enhanced to improve the retrieval of configurations based on keywords. The message formatting for user instructions has also been refined for clarity.