### PR TITLE
Fix API changes to use input schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "name": "searchConfigurations",
         "displayName": "Search Configurations",
         "modelDescription": "Use this tool to search for settings and commands. This will return all those settings and commands that contain the provided keywords. Each result will have a type to know if it is a setting or a command. A setting includes the description, default value, current value and other possible values and a command includes the description and possible arguments to be used to invoke the command.",
-        "parametersSchema": {
+        "inputSchema": {
           "type": "object",
           "properties": {
             "keywords": {
@@ -58,7 +58,7 @@
         "tags": [
           "commander"
         ],
-        "parametersSchema": {
+        "inputSchema": {
           "type": "object",
           "description": "Dictionary of settings to update. The key is the setting id and the value is the new value of the setting.",
           "properties": {}
@@ -71,7 +71,7 @@
         "tags": [
           "commander"
         ],
-        "parametersSchema": {
+        "inputSchema": {
           "type": "object",
           "properties": {
             "key": {

--- a/src/chatParticipant.tsx
+++ b/src/chatParticipant.tsx
@@ -94,7 +94,7 @@ class ToolCallElement extends PromptElement<ToolCallElementProps, void> {
 		};
 
 		const toolResult = this.props.toolCallResult ??
-			await vscode.lm.invokeTool(this.props.toolCall.name, { parameters: this.props.toolCall.parameters, toolInvocationToken: this.props.toolInvocationToken, tokenizationOptions }, new vscode.CancellationTokenSource().token);
+			await vscode.lm.invokeTool(this.props.toolCall.name, { input: this.props.toolCall.input, toolInvocationToken: this.props.toolInvocationToken, tokenizationOptions }, new vscode.CancellationTokenSource().token);
 
 		const data = getTsxDataFromToolsResult(toolResult);
 		if (!data) {
@@ -128,7 +128,7 @@ class ToolCalls extends PromptElement<ToolCallsProps, void> {
 	}
 
 	private renderOneToolCallRound(round: ToolCallRound) {
-		const assistantToolCalls: ToolCall[] = round.toolCalls.map(tc => ({ type: 'function', function: { name: tc.name, arguments: JSON.stringify(tc.parameters) }, id: tc.callId }));
+		const assistantToolCalls: ToolCall[] = round.toolCalls.map(tc => ({ type: 'function', function: { name: tc.name, arguments: JSON.stringify(tc.input) }, id: tc.callId }));
 		return <Chunk>
 			<AssistantMessage toolCalls={assistantToolCalls}>{round.response}</AssistantMessage>
 			{round.toolCalls.map(toolCall =>
@@ -204,7 +204,7 @@ export default function (
 			.map<vscode.LanguageModelChatTool>(t => ({
 				name: t.name,
 				description: t.description,
-				parametersSchema: t.parametersSchema
+				parametersSchema: t.inputSchema,
 			}));
 
 

--- a/src/tools/runCommands.tsx
+++ b/src/tools/runCommands.tsx
@@ -20,7 +20,7 @@ const commandsWithComplexArguments = new Set(['vscode.setEditorLayout']);
 const complexArgumentSetterTool: vscode.LanguageModelChatTool = {
    name: 'SetArgument',
    description: 'Use this tool to set the argument for the command',
-   parametersSchema: {
+   inputSchema: {
       type: "object",
       properties: {
          argument: {
@@ -73,7 +73,7 @@ export class RunCommand implements vscode.LanguageModelTool<{ key?: string, argu
 
    prepareInvocation(options: vscode.LanguageModelToolInvocationPrepareOptions<{ key?: string, argumentsArray?: string }>, token: vscode.CancellationToken): vscode.ProviderResult<vscode.PreparedToolInvocation> {
       // validate parameters
-      const commandId = options.parameters.key;
+      const commandId = options.input.key;
       if (typeof commandId !== 'string' || !commandId.length) {
          return undefined;
       }
@@ -86,7 +86,7 @@ export class RunCommand implements vscode.LanguageModelTool<{ key?: string, argu
 
    async invoke(options: vscode.LanguageModelToolInvocationOptions<{ key?: string, argumentsArray?: string }>, token: vscode.CancellationToken): Promise<vscode.LanguageModelToolResult> {
       // validate parameters
-      const commandId = options.parameters.key;
+      const commandId = options.input.key;
       if (typeof commandId !== 'string' || !commandId.length) {
          return await this.createToolErrorResult('Not able to change because the parameter is missing or invalid', options, token);
       }
@@ -98,7 +98,7 @@ export class RunCommand implements vscode.LanguageModelTool<{ key?: string, argu
       }
 
       // Parse arguments
-      const parsedArgs = await this.parseArguments(options.parameters.argumentsArray, command, token);
+      const parsedArgs = await this.parseArguments(options.input.argumentsArray, command, token);
       if (parsedArgs.errorMessage) {
          return await this.createToolErrorResult(parsedArgs.errorMessage, options, token);
       }
@@ -199,8 +199,8 @@ export class RunCommand implements vscode.LanguageModelTool<{ key?: string, argu
             continue;
          }
 
-         if ('argument' in message.parameters && typeof message.parameters.argument === 'string') {
-            argument = JSON.parse(message.parameters.argument);
+         if ('argument' in message.input && typeof message.input.argument === 'string') {
+            argument = JSON.parse(message.input.argument);
             break;
          }
       }

--- a/src/tools/searchConfigurations.tsx
+++ b/src/tools/searchConfigurations.tsx
@@ -52,7 +52,7 @@ export class SearchConfigurations implements vscode.LanguageModelTool<{ keywords
 	}
 
 	async invoke(options: vscode.LanguageModelToolInvocationOptions<{ keywords?: string }>, token: vscode.CancellationToken) {
-		const keywords = options.parameters.keywords;
+		const keywords = options.input.keywords;
 		if (!keywords) {
 			return await this.createToolErrorResult('Unable to call searchConfigurations without keywords', options, token);
 		}

--- a/src/tools/updateSettings.tsx
+++ b/src/tools/updateSettings.tsx
@@ -77,7 +77,7 @@ export class UpdateSettings implements vscode.LanguageModelTool<Record<string, a
    }
 
    async prepareInvocation(options: vscode.LanguageModelToolInvocationPrepareOptions<Record<string, any>>, token: vscode.CancellationToken): Promise<vscode.PreparedToolInvocation | undefined> {
-      const settingsToUpdate = this.validateSettings(options.parameters ?? {});
+      const settingsToUpdate = this.validateSettings(options.input ?? {});
 
       if (settingsToUpdate.length === 0) {
          return undefined;
@@ -113,7 +113,7 @@ export class UpdateSettings implements vscode.LanguageModelTool<Record<string, a
    }
 
    async invoke(options: vscode.LanguageModelToolInvocationOptions<Record<string, any>>, token: vscode.CancellationToken) {
-      const settingsToUpdate = this.validateSettings(options.parameters ?? {});
+      const settingsToUpdate = this.validateSettings(options.input ?? {});
 
       if (settingsToUpdate.length === 0) {
          return await this.createToolErrorResult('No settings to update', options, token);

--- a/vscode.d.ts
+++ b/vscode.d.ts
@@ -19096,7 +19096,7 @@ declare module 'vscode' {
 		 * The list of tools that the user attached to their request.
 		 *
 		 * When a tool reference is present, the chat participant should make a chat request using
-		 * {@link LanguageModelChatToolMode.Required} to force the language model to generate parameters for the tool. Then, the
+		 * {@link LanguageModelChatToolMode.Required} to force the language model to generate input for the tool. Then, the
 		 * participant can use {@link lm.invokeTool} to use the tool attach the result to its request for the user's prompt. The
 		 * tool may contribute useful extra context for the user's request.
 		 */
@@ -19703,12 +19703,12 @@ declare module 'vscode' {
 
 		/**
 		 * A list of all available tools that were registered by all extensions using {@link lm.registerTool}. They can be called
-		 * with {@link lm.invokeTool} with a set of parameters that match their declared `parametersSchema`.
+		 * with {@link lm.invokeTool} with input that match their declared `inputSchema`.
 		 */
 		export const tools: readonly LanguageModelToolInformation[];
 
 		/**
-		 * Invoke a tool listed in {@link lm.tools} by name with the given parameters. The parameters will be validated against
+		 * Invoke a tool listed in {@link lm.tools} by name with the given input. The input will be validated against
 		 * the schema declared by the tool
 		 *
 		 * A tool can be invoked by a chat participant, in the context of handling a chat request, or globally by any extension in
@@ -19774,9 +19774,9 @@ declare module 'vscode' {
 		description: string;
 
 		/**
-		 * A JSON schema for the parameters this tool accepts.
+		 * A JSON schema for the input this tool accepts.
 		 */
-		parametersSchema?: object;
+		inputSchema?: object;
 	}
 
 	/**
@@ -19811,18 +19811,18 @@ declare module 'vscode' {
 		name: string;
 
 		/**
-		 * The parameters with which to call the tool.
+		 * The input with which to call the tool.
 		 */
-		parameters: object;
+		input: object;
 
 		/**
 		 * Create a new LanguageModelToolCallPart.
 		 *
 		 * @param callId The ID of the tool call.
 		 * @param name The name of the tool to call.
-		 * @param parameters The parameters with which to call the tool.
+		 * @param input The input with which to call the tool.
 		 */
-		constructor(callId: string, name: string, parameters: object);
+		constructor(callId: string, name: string, input: object);
 	}
 
 	/**
@@ -19924,10 +19924,10 @@ declare module 'vscode' {
 		toolInvocationToken: ChatParticipantToolToken | undefined;
 
 		/**
-		 * The parameters with which to invoke the tool. The parameters must match the schema defined in
-		 * {@link LanguageModelToolInformation.parametersSchema}
+		 * The input with which to invoke the tool. The input must match the schema defined in
+		 * {@link LanguageModelToolInformation.inputSchema}
 		 */
-		parameters: T;
+		input: T;
 
 		/**
 		 * Options to hint at how many tokens the tool should return in its response, and enable the tool to count tokens
@@ -19969,9 +19969,9 @@ declare module 'vscode' {
 		readonly description: string;
 
 		/**
-		 * A JSON schema for the parameters this tool accepts.
+		 * A JSON schema for the input this tool accepts.
 		 */
-		readonly parametersSchema: object | undefined;
+		readonly inputSchema: object | undefined;
 
 		/**
 		 * A set of tags, declared by the tool, that roughly describe the tool's capabilities. A tool user may use these to filter
@@ -19985,9 +19985,9 @@ declare module 'vscode' {
 	 */
 	export interface LanguageModelToolInvocationPrepareOptions<T> {
 		/**
-		 * The parameters that the tool is being invoked with.
+		 * The input that the tool is being invoked with.
 		 */
-		parameters: T;
+		input: T;
 	}
 
 	/**
@@ -19995,15 +19995,15 @@ declare module 'vscode' {
 	 */
 	export interface LanguageModelTool<T> {
 		/**
-		 * Invoke the tool with the given parameters and return a result.
+		 * Invoke the tool with the given input and return a result.
 		 *
-		 * The provided {@link LanguageModelToolInvocationOptions.parameters} have been validated against the declared schema.
+		 * The provided {@link LanguageModelToolInvocationOptions.input} has been validated against the declared schema.
 		 */
 		invoke(options: LanguageModelToolInvocationOptions<T>, token: CancellationToken): ProviderResult<LanguageModelToolResult>;
 
 		/**
 		 * Called once before a tool is invoked. It's recommended to implement this to customize the progress message that appears
-		 * while the tool is running, and to provide a more useful message with context from the invocation parameters. Can also
+		 * while the tool is running, and to provide a more useful message with context from the invocation input. Can also
 		 * signal that a tool needs user confirmation before running, if appropriate.
 		 *
 		 * * *Note 1:* Must be free of side-effects.


### PR DESCRIPTION
Update the API to replace `parametersSchema` with `inputSchema` across various tools and functions, ensuring consistency in how input is handled. 